### PR TITLE
Bump et_consul to 3.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ version          '2.0.1'
 supports 'ubuntu', '>= 14.04'
 
 depends 'hashicorp-vault', '~> 2.1'
-depends 'et_consul', '~> 2.0'
+depends 'et_consul', '~> 3.0'


### PR DESCRIPTION
Note that the latest tagged version of the cookbook doesn't even list `et_consul` as a dependency. It "works" because, on the nodes where it is deployed, `et_consul` is already in the run list. So, in fact, if a release were to be cut without first merging this in, we would actually be forcing a downgrade of `et_consul` because the current live version of *that* cookbook is `3.0.2`.